### PR TITLE
mark-devkit: [mark-unstable] Bump dev-python/pdm-backend-2.4.5-r1

### DIFF
--- a/dev-python/pdm-backend/pdm-backend-2.4.5-r1.ebuild
+++ b/dev-python/pdm-backend/pdm-backend-2.4.5-r1.ebuild
@@ -15,6 +15,7 @@ KEYWORDS="*"
 RDEPEND="
 	>=dev-python/packaging-24.0[${PYTHON_USEDEP}]
 	dev-python/editables[${PYTHON_USEDEP}]
+	dev-python/importlib_metadata[${PYTHON_USEDEP}]
 	dev-python/pyproject-metadata[${PYTHON_USEDEP}]
 	dev-python/tomli[${PYTHON_USEDEP}]
 	dev-python/tomli-w[${PYTHON_USEDEP}]
@@ -22,6 +23,7 @@ RDEPEND="
 DEPEND="
 	>=dev-python/packaging-24.0[${PYTHON_USEDEP}]
 	dev-python/editables[${PYTHON_USEDEP}]
+	dev-python/importlib_metadata[${PYTHON_USEDEP}]
 	dev-python/pyproject-metadata[${PYTHON_USEDEP}]
 	dev-python/tomli[${PYTHON_USEDEP}]
 	dev-python/tomli-w[${PYTHON_USEDEP}]


### PR DESCRIPTION
Automatic bump of package dev-python/pdm-backend-2.4.5-r1 for branch mark-unstable by mark-bot