### PR TITLE
mark-devkit: [mark-xl] Bump dev-python/hatch-vcs-0.5.0-r1

### DIFF
--- a/dev-python/hatch-vcs/hatch-vcs-0.5.0-r1.ebuild
+++ b/dev-python/hatch-vcs/hatch-vcs-0.5.0-r1.ebuild
@@ -17,6 +17,6 @@ RDEPEND="
 DEPEND="
 	dev-python/setuptools_scm[${PYTHON_USEDEP}]
 "
-S="${WORKDIR}/hatch-vcs-0.5.0"
+S="${WORKDIR}/hatch_vcs-0.5.0"
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-python/hatch-vcs-0.5.0-r1 for branch mark-xl by mark-bot