### PR TITLE
mark-devkit: [mark-31] Bump dev-util/maturin-1.9.6-r1

### DIFF
--- a/dev-util/maturin/maturin-1.9.6-r1.ebuild
+++ b/dev-util/maturin/maturin-1.9.6-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-python/tomli[${PYTHON_USEDEP}]
 "
 DEPEND="
-	dev-python/setuptools-rust[${PYTHON_USEDEP}]
+	>=dev-python/setuptools-rust-1.11.1[${PYTHON_USEDEP}]
 "
 S="${WORKDIR}/maturin-1.9.6"
 src_unpack() {


### PR DESCRIPTION
Automatic bump of package dev-util/maturin-1.9.6-r1 for branch mark-31 by mark-bot